### PR TITLE
問題点4「画面端にこすりつけると見える裏画面が気になる」

### DIFF
--- a/Assets/Scripts/DragMove.cs
+++ b/Assets/Scripts/DragMove.cs
@@ -23,26 +23,52 @@ public class DragMove : MonoBehaviour,IDragHandler, IBeginDragHandler, IEndDragH
             //Debug.Log(eventData);
             Vector2 vec = eventData.delta;
 
-            if (_rectTransform.anchoredPosition.x >= 27900)
+            // if (_rectTransform.anchoredPosition.x >= 27900)
+            // {
+            //     vec = new Vector2(-1f, vec.y);
+            // }
+            // else if (_rectTransform.anchoredPosition.x <= -27900)
+            // {
+            //     vec = new Vector2(1f, vec.y);
+            // }
+            //
+            // if (_rectTransform.anchoredPosition.y >= 19590)
+            // {
+            //     vec = new Vector2(vec.x, -1f);
+            //
+            // }
+            // else if (_rectTransform.anchoredPosition.y <= -19590)
+            // {
+            //     vec = new Vector2(vec.x, 1f);
+            // }
+            
+            // 移動量を表すベクター
+            Vector2 Movement = vec * _speed;
+            
+            if (_rectTransform.anchoredPosition.x + Movement.x >= 27900)
             {
-                vec = new Vector2(-1f, vec.y);
+                Movement = new Vector2(0f, Movement.y);
+                _rectTransform.anchoredPosition = new Vector2(27899, _rectTransform.anchoredPosition.y);
             }
-            else if (_rectTransform.anchoredPosition.x <= -27900)
+            else if (_rectTransform.anchoredPosition.x + Movement.x <= -27900)
             {
-                vec = new Vector2(1f, vec.y);
+                Movement = new Vector2(0f, Movement.y);
+                _rectTransform.anchoredPosition = new Vector2(-27899, _rectTransform.anchoredPosition.y);
             }
 
-            if (_rectTransform.anchoredPosition.y >= 19590)
+            if (_rectTransform.anchoredPosition.y + Movement.y >= 19590)
             {
-                vec = new Vector2(vec.x, -1f);
-
+                Movement = new Vector2(Movement.x, 0f);
+                _rectTransform.anchoredPosition = new Vector2(_rectTransform.anchoredPosition.x, 19589);
             }
-            else if (_rectTransform.anchoredPosition.y <= -19590)
+            else if (_rectTransform.anchoredPosition.y + Movement.y <= -19590)
             {
-                vec = new Vector2(vec.x, 1f);
+                Movement = new Vector2(Movement.x, 0f);
+                _rectTransform.anchoredPosition = new Vector2(_rectTransform.anchoredPosition.x, -19589);
             }
 
-            _rectTransform.anchoredPosition += vec * _speed;
+            //_rectTransform.anchoredPosition += vec * _speed;
+            _rectTransform.anchoredPosition += Movement;
         }
 
     }


### PR DESCRIPTION
原因
移動を制限する条件と後処理が甘かったために起こった

解決
移動を制限する際の条件と後処理に手を加えた。
マップの現在の座標に移動量を加えた値が規定値を超えた際に
移動量を0にしてマップの現在座標を規定値一歩手前に更新することで解決した。