### PR TITLE
[HotFix] 拡大時にアイコンが押しにくい問題が戻った

### DIFF
--- a/Assets/Scripts/ZoomCamera.cs
+++ b/Assets/Scripts/ZoomCamera.cs
@@ -95,8 +95,10 @@ public class ZoomCamera : MonoBehaviour
         SoundManager.instance.PlayAudioSorce(AudioOfType.SYSTEMSE, _Channel);
         ZoomCount(1);
     }
-    public void ZoomCount(int _count)
+    public void ZoomCount(int count)
     {
+        _count = count;
+        
         switch (_count)
         {
             case 1:


### PR DESCRIPTION
# 概要
拡大縮小のメソッド化にともなってエンバグが発生した

# 原因
引数が変数に保存されておらず、結果ほかの機能の稼働を阻害していた

エンバグに気をつけてください。　自分がいま何をしているのかを明確に、　変数名などのルールは守りましょう。